### PR TITLE
fix(core): correct Quantity power behavior and add float-drift tolerance

### DIFF
--- a/tests/test_dimensions.py
+++ b/tests/test_dimensions.py
@@ -2,19 +2,11 @@ import pytest
 
 # If your file lives at src/quantium/units/dimensions.py, this import will work:
 from quantium.core.dimensions import (
-    AMOUNT,
-    CURRENT,
-    DIM_0,
-    LENGTH,
-    LUMINOUS,
-    MASS,
-    TEMPERATURE,
-    TIME,
     Dim,
-    dim_div,
-    dim_mul,
-    dim_pow,
+    LENGTH, MASS, TIME, CURRENT, TEMPERATURE, AMOUNT, LUMINOUS, DIM_0,
+    dim_mul, dim_div, dim_pow
 )
+
 
 # --- Basic structure & base vectors -------------------------------------------------
 
@@ -47,7 +39,7 @@ def test_dimensional_basis():
 ])
 def test_dim_mul(a, b, expected):
     # vector add of exponents
-    assert dim_mul(a, b) == tuple(x+y for x,y in zip(a,b, strict=False))
+    assert dim_mul(a, b) == tuple(x+y for x,y in zip(a,b))
     # commutativity
     assert dim_mul(a, b) == dim_mul(b, a)
     # selected expected checks

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -501,3 +501,119 @@ def test_unit_name_changes_do_not_affect_equality():
     m_alias = m.as_name("meter")
     assert m_alias.name != m.name
     assert m_alias == m
+
+
+@pytest.mark.regression(reason="Issue: #33 Unit raised to power 0 is not dimensionless")
+def test_quantity_pow_zero_and_one_and_negative():
+    m = Unit("m", 1.0, LENGTH)
+    q = 2 @ m
+    q0 = q ** 0
+    q1 = q ** 1
+    qn = q ** -2
+    assert q0.dim == DIM_0 and q0.unit.scale_to_si == 1.0
+    assert q1.dim == LENGTH
+    assert qn.dim == dim_pow(LENGTH, -2)
+
+
+
+def _name(sym: str, n: int) -> str:
+    return "1" if n == 0 else (sym if n == 1 else f"{sym}^{n}")
+
+# -------------------------
+# Regression: Issue #33 (Unit)
+# -------------------------
+
+@pytest.mark.regression(reason="Issue #33: negative exponents should produce correct dim/name/scale")
+@pytest.mark.parametrize("n", [-3, -4])
+@pytest.mark.parametrize("sym, scale", [("m", 1.0), ("cm", 0.01)])
+def test_unit_pow_negative_high_exponents_regression_issue_33(sym: str, scale: float, n: int):
+    u = Unit(sym, scale, LENGTH)
+    up = u ** n
+
+    # Dimension and name
+    assert up.dim == dim_pow(LENGTH, n)
+    assert up.name == _name(sym, n)
+
+    # Scale: scale_to_si ** n (e.g., (0.01)**-3 = 1_000_000)
+    assert up.scale_to_si == pytest.approx(scale ** n)
+
+    # Reciprocal sanity
+    assert (1 / (u ** (-n))) == (u ** n)
+
+
+# -------------------------
+# Regression: Issue #33 (Quantity)
+# -------------------------
+
+@pytest.mark.regression(reason="Issue #33: Quantity ** n must match dim, unit, and magnitude for negative exponents")
+@pytest.mark.parametrize("n", [-3, -4])
+@pytest.mark.parametrize("sym, scale, value", [
+    ("m",  1.0,  2.0),
+    ("cm", 0.01, 5.0),
+])
+def test_quantity_pow_negative_high_exponents_regression_issue_33(sym: str, scale: float, value: float, n: int):
+    u = Unit(sym, scale, LENGTH)
+    q = value @ u
+    qp = q ** n
+
+    # Dimension & unit name/scale
+    assert qp.dim == dim_pow(LENGTH, n)
+    assert qp.unit.name == _name(sym, n)
+    assert qp.unit.scale_to_si == pytest.approx(scale ** n)
+
+    # Magnitude in the resulting unit should be value**n
+    mag_in_unit = qp._mag_si / qp.unit.scale_to_si
+    assert math.isclose(mag_in_unit, value ** n, rel_tol=1e-12, abs_tol=1e-12)
+
+
+
+# NOTE:
+# These tests rely on the classic binary rounding facts:
+#   0.1 * 0.2 != 0.02 exactly
+#   3 * 0.1 != 0.3 exactly
+# so exact float equality will fail. The library should tolerate tiny drift.
+
+
+@pytest.mark.regression(reason="Float drift: Unit equality should tolerate tiny scale differences")
+def test_unit_equality_tolerates_scale_float_drift():
+    # Two mathematically identical scales obtained via different FP paths.
+    u1 = Unit("a", 0.1, LENGTH) * Unit("b", 0.2, LENGTH)     # scale ~ 0.020000000000000004
+    u2 = Unit("c", 0.02, dim_pow(LENGTH, 2))                  # scale 0.02
+
+    # If Unit.__eq__ uses exact float equality, this will fail.
+    # After fixing, __eq__ should consider them equal (same dim, scales within tolerance).
+    assert u1 == u2, f"scales differ slightly: {u1.scale_to_si} vs {u2.scale_to_si}"
+
+
+@pytest.mark.regression(reason="Float drift: Quantity equality should use tolerant SI magnitude comparison")
+def test_quantity_equality_tolerates_si_float_drift():
+    m = Unit("m", 1.0, LENGTH)
+    a = Unit("a", 0.1, LENGTH)
+
+    q1 = 3 @ a      # _mag_si ~ 0.30000000000000004
+    q2 = 0.3 @ m    # _mag_si ~ 0.29999999999999999
+
+    # Exact equality on _mag_si will fail. After fix, should pass.
+    assert q1 == q2, f"_mag_si differ slightly: {q1._mag_si} vs {q2._mag_si}"
+
+
+@pytest.mark.regression(reason="Float drift: Dimensionless ratios should be numerically 1 within tolerance")
+def test_dimensionless_ratio_avoids_float_drift():
+    m = Unit("m", 1.0, LENGTH)
+    a = Unit("a", 0.1, LENGTH)
+
+    num = 3 @ a       # SI ~ 0.30000000000000004
+    den = 0.3 @ m     # SI ~ 0.29999999999999999
+    r = num / den     # should be dimensionless 1
+
+    # 1) Dimensionless dim
+    assert r.dim == DIM_0
+
+    # 2) Canonical dimensionless unit (empty name, scale 1.0)
+    assert r.unit.name == ""
+    assert r.unit.scale_to_si == 1.0
+
+    # 3) Numeric value ~ 1, allow tiny drift (repr shows the magnitude in current unit)
+    # If repr prints a bare number for dimensionless quantities, cast to float safely:
+    val = float(repr(r))
+    assert val == pytest.approx(1.0, rel=1e-12, abs=1e-15)


### PR DESCRIPTION
This commit resolves three related numerical and logical issues in the Quantity and Unit classes:

1. Quantity exponentiation now correctly respects the given power `n`.
   - Previously, `__pow__` always squared the unit (`unit ** 2`) regardless of the exponent.
   - `q ** 0` now produces a dimensionless quantity (DIM_0) as expected.
   - Unit names and dimensions now update correctly (e.g., m³, m⁻², etc.).

2. Fixed incorrect unit name retention during exponentiation.
   - Unit names no longer stay constant at "m²" for all powers.

3. Added tolerance for floating-point drift in equality checks.
   - `Unit.__eq__` and `Quantity.__eq__` now use `math.isclose()` to compare `scale_to_si` and `_mag_si`, preventing false negatives due to rounding (e.g., 0.30000000000000004 vs 0.3).

Closes #33, #34