### PR TITLE
feat(quantity): support prefixed SI symbols (e.g., µN, kPa, mW) in __repr__

### DIFF
--- a/src/quantium/units/prefixes.py
+++ b/src/quantium/units/prefixes.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+# ---------------------------------------------------------------------------
+# Prefix model
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Prefix:
+    symbol: str
+    factor: float
+
+# SI prefixes including 2022 additions (quetta/ronna/ronto/quecto)
+PREFIXES: Tuple[Prefix, ...] = (
+    # large
+    Prefix("Q", 1e30),  # quetta
+    Prefix("R", 1e27),  # ronna
+    Prefix("Y", 1e24),  # yotta
+    Prefix("Z", 1e21),  # zetta
+    Prefix("E", 1e18),  # exa
+    Prefix("P", 1e15),  # peta
+    Prefix("T", 1e12),  # tera
+    Prefix("G", 1e9),   # giga
+    Prefix("M", 1e6),   # mega
+    Prefix("k", 1e3),   # kilo
+    Prefix("h", 1e2),   # hecto
+    Prefix("da", 1e1),  # deca (two letters)
+    # small
+    Prefix("d", 1e-1),  # deci
+    Prefix("c", 1e-2),  # centi
+    Prefix("m", 1e-3),  # milli
+    Prefix("µ", 1e-6),  # micro (Greek mu)
+    Prefix("n", 1e-9),  # nano
+    Prefix("p", 1e-12), # pico
+    Prefix("f", 1e-15), # femto
+    Prefix("a", 1e-18), # atto
+    Prefix("z", 1e-21), # zepto
+    Prefix("y", 1e-24), # yocto
+    Prefix("r", 1e-27), # ronto
+    Prefix("q", 1e-30), # quecto
+)

--- a/src/quantium/units/registry.py
+++ b/src/quantium/units/registry.py
@@ -338,7 +338,6 @@ DEFAULT_REGISTRY: UnitsRegistry = _bootstrap_default_registry()
 
 
 __all__ = [
-    "Prefix",
     "UnitsRegistry",
     "DEFAULT_REGISTRY",
 ]

--- a/src/quantium/units/registry.py
+++ b/src/quantium/units/registry.py
@@ -21,11 +21,12 @@ Assumptions
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+
 import re
 import threading
 from typing import Dict, Iterable, Mapping, Optional, Tuple
 import unicodedata
+from quantium.units.prefixes import PREFIXES
 
 from quantium.core.dimensions import (
     AMOUNT,
@@ -43,43 +44,7 @@ from quantium.core.dimensions import (
 from quantium.core.quantity import Unit
 
 
-# ---------------------------------------------------------------------------
-# Prefix model
-# ---------------------------------------------------------------------------
-@dataclass(frozen=True)
-class Prefix:
-    symbol: str
-    factor: float
 
-# SI prefixes including 2022 additions (quetta/ronna/ronto/quecto)
-PREFIXES: Tuple[Prefix, ...] = (
-    # large
-    Prefix("Q", 1e30),  # quetta
-    Prefix("R", 1e27),  # ronna
-    Prefix("Y", 1e24),  # yotta
-    Prefix("Z", 1e21),  # zetta
-    Prefix("E", 1e18),  # exa
-    Prefix("P", 1e15),  # peta
-    Prefix("T", 1e12),  # tera
-    Prefix("G", 1e9),   # giga
-    Prefix("M", 1e6),   # mega
-    Prefix("k", 1e3),   # kilo
-    Prefix("h", 1e2),   # hecto
-    Prefix("da", 1e1),  # deca (two letters)
-    # small
-    Prefix("d", 1e-1),  # deci
-    Prefix("c", 1e-2),  # centi
-    Prefix("m", 1e-3),  # milli
-    Prefix("µ", 1e-6),  # micro (Greek mu)
-    Prefix("n", 1e-9),  # nano
-    Prefix("p", 1e-12), # pico
-    Prefix("f", 1e-15), # femto
-    Prefix("a", 1e-18), # atto
-    Prefix("z", 1e-21), # zepto
-    Prefix("y", 1e-24), # yocto
-    Prefix("r", 1e-27), # ronto
-    Prefix("q", 1e-30), # quecto
-)
 
 # Ordered list of prefix symbols by descending length for robust matching
 _PREFIX_SYMBOLS_DESC = tuple(sorted((p.symbol for p in PREFIXES), key=len, reverse=True))


### PR DESCRIPTION


- Enhanced Quantity.__repr__ to detect total scale_to_si and apply an appropriate SI prefix.
- Composed units like mg·µm/ms² now print as "µN" instead of staying expanded.
- Added comprehensive pytest suite covering multiple SI families:
  - Force (N, µN, kN)
  - Current (A, mA)
  - Power (W, mW)
  - Pressure (Pa, kPa, MPa)
  - Frequency (Hz, kHz, MHz)
- Ensures atomic symbols (Pa, Hz, Bq, Sv, Gy) are never flipped.